### PR TITLE
pref: use transformers embeddings (all-MiniLM-L6-v2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9-eclipse-temurin-21-alpine AS build
+FROM maven:3.9-eclipse-temurin-21 AS build
 
 WORKDIR /app
 
@@ -11,10 +11,10 @@ COPY src ./src
 
 RUN ./mvnw clean package -DskipTests
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 
-RUN addgroup -S spring && adduser -S spring -G spring
+RUN groupadd -r spring && useradd -r -g spring spring
 
 COPY --from=build /app/target/upply-*.jar app.jar
 

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 
 		<dependency>
 			<groupId>org.springframework.ai</groupId>
-			<artifactId>spring-ai-starter-model-google-genai-embedding</artifactId>
+			<artifactId>spring-ai-starter-model-transformers</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,19 +39,25 @@ spring:
     virtual:
       enabled: true
   ai:
-    google:
-      genai:
-        embedding:
-          api-key: ${GEMINI_API}
-          text:
-            options:
-              model: text-embedding-004
-              task-type: semantic_similarity
+    model:
+      embedding: transformers
+    embedding:
+      transformer:
+        cache:
+          enabled: true
+          directory: /tmp/spring-ai-onnx-model
+        tokenizer:
+          uri: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json
+        onnx:
+          model-uri: https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx
+
     vectorstore:
       redis:
         initialize-schema: true
         index-name: upply-vector-index
-        prefix: upply:embedding
+        prefix: "upply:embedding:"
+        dimension: 384
+
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## Summary

This PR replaces the Gemini embedding model with a Sentence-BERT (SBERT) Transformer embedding model (all-MiniLM-L6-v2) using ONNX, and updates the Docker base image to Debian family for better ML runtime support.

## Why this change

- SBERT provides stronger semantic similarity for matching jobs and profiles, and  validated in research for recommendation systems.

- ONNX-based Transformer embeddings run locally, removing dependency on external APIs and ensuring deterministic, reproducible vectors. Additionally, this enables running PyTorch Transformers from Java instead of Python, simplifying integration in our Spring AI stack.

- Debian-based Docker image offers richer native libraries required by ONNX Runtime and DJl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Transitioned embedding infrastructure from cloud-based GenAI service to local transformer-based models, reducing external dependencies and improving latency
  * Updated Docker deployment stack with revised base images and enhanced user management configuration
  * Reconfigured vectorstore settings to align with new embedding model specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->