### PR TITLE
fix(config): move Kafka SSL options under 'properties' for consistency

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,17 +70,15 @@ spring:
           connection-string: ${OBSERVE}
   kafka:
     bootstrap-servers: ${KAFKA_URL}
-    # Move SSL settings out of 'properties' into 'ssl'
-    ssl:
-      trust-store-location: ${KAFKA_TRUSTSTORE_PATH}
-      trust-store-password: ${KAFKA_SSL_PASSWORD}
-      trust-store-type: JKS
-      key-store-location: ${KAFKA_KEYSTORE_PATH}
-      key-store-password: ${KAFKA_SSL_PASSWORD}
-      key-store-type: PKCS12
-      key-password: ${KAFKA_SSL_PASSWORD}
     properties:
       security.protocol: SSL
+      ssl.truststore.location: file:${KAFKA_TRUSTSTORE_PATH}
+      ssl.truststore.password: ${KAFKA_SSL_PASSWORD}
+      ssl.truststore.type: JKS
+      ssl.keystore.location: file:${KAFKA_KEYSTORE_PATH}
+      ssl.keystore.password: ${KAFKA_SSL_PASSWORD}
+      ssl.keystore.type: PKCS12
+      ssl.key.password: ${KAFKA_SSL_PASSWORD}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized Kafka SSL configuration structure to align with standard property naming conventions while preserving all existing security settings and protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->