### PR TITLE
feat(job): make export tasks configurable

### DIFF
--- a/src/main/java/com/upply/job/ExportTask.java
+++ b/src/main/java/com/upply/job/ExportTask.java
@@ -2,6 +2,7 @@ package com.upply.job;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.time.Instant;
 
@@ -17,15 +18,15 @@ public class ExportTask {
     private final Long jobId;
     private volatile Status status;
     private volatile byte[] data;
-    private volatile String errorMessage;
+    private String errorMessage;
     private final Instant createdAt;
-    private Instant expireAt;
+    private final Instant expireAt;
 
-    public ExportTask(String taskId, Long jobId) {
+    public ExportTask(String taskId, Long jobId, int taskExportTime) {
         this.taskId = taskId;
         this.jobId = jobId;
         this.status = Status.PROCESSING;
         this.createdAt = Instant.now();
-        this.expireAt = Instant.now().plusSeconds(600);
+        this.expireAt = Instant.now().plusSeconds(taskExportTime);
     }
 }

--- a/src/main/java/com/upply/job/JobService.java
+++ b/src/main/java/com/upply/job/JobService.java
@@ -22,6 +22,7 @@ import com.upply.user.User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -56,6 +57,8 @@ public class JobService {
     private final KafkaTemplate<String, NotificationEvent> notificationKafkaTemplate;
     //TODO: use key-value database like redis!!
     private final Map<String, ExportTask> exportTasks = new ConcurrentHashMap<>();
+    @Value("${app.export.task-expire-seconds}")
+    private int TASK_EXPIRE_TIME;
 
     @Transactional
     public JobResponse createJob(@Valid JobRequest request, Authentication connectedUser) {
@@ -355,7 +358,7 @@ public class JobService {
                 applications.isFirst(),
                 applications.isLast());
     }
-
+    // export application to excel file
     public ExportTaskResponse startExportTask(Long jobId, Authentication connectedUser) {
         Job job = jobRepository.findById(jobId)
                 .orElseThrow(() -> new ResourceNotFoundException("Job with ID " + jobId + " not found"));
@@ -376,7 +379,7 @@ public class JobService {
 
 
         String taskId = UUID.randomUUID().toString();
-        ExportTask task = new ExportTask(taskId, jobId);
+        ExportTask task = new ExportTask(taskId, jobId,TASK_EXPIRE_TIME);
         exportTasks.put(taskId, task);
 
         Thread.ofVirtual().name("export-job-" + jobId).start(() -> processExport(task, applications));
@@ -444,7 +447,7 @@ public class JobService {
         return task.getData();
     }
 
-    @Scheduled(fixedDelay = 60_000)
+    @Scheduled(fixedDelayString = "${app.export.cleanup-interval-ms}")
     public void cleanExpiredTasks() {
         exportTasks.entrySet().removeIf(
                 entry -> entry.getValue().getExpireAt().isBefore(Instant.now())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,9 @@ jwt:
 
 app:
   activation-base-url: "http://localhost:8080/api/v1/auth/activate"
+  export:
+    task-expire-seconds: ${TASK_EXPIRE_SECONDS}
+    cleanup-interval-ms: ${SCULDER_CLEANUP_TIME}
 
 azure:
   storage:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -82,7 +82,9 @@ jwt:
 
 app:
   activation-base-url: "http://localhost:8080/api/v1/auth/activate"
-
+  export:
+    task-expire-seconds: 600
+    cleanup-interval-ms: 36000
   azure:
     storage:
       account-name: test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Export task expiration time is now configurable via application configuration instead of a hardcoded value.
  * Export task cleanup interval is now configurable via application configuration instead of a hardcoded schedule.
  * Task expiration state handling updated for more reliable lifecycle management.
* **Tests**
  * Test configuration updated to include the new export timeout and cleanup interval settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->