### PR TITLE
feat(job): add redis caching for job create, get, close operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
 			<groupId>org.springframework.ai</groupId>
 			<artifactId>spring-ai-starter-model-openai</artifactId>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/upply/UpplyApplication.java
+++ b/src/main/java/com/upply/UpplyApplication.java
@@ -2,12 +2,14 @@ package com.upply;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
 @EnableScheduling
+@EnableCaching
 public class UpplyApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/upply/config/RedisConfig.java
+++ b/src/main/java/com/upply/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.upply.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.activateDefaultTyping(
+                objectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL);
+
+        Jackson2JsonRedisSerializer<Object> serializer = new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+
+        RedisCacheConfiguration redisCacheConfiguration= RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(2))
+                .disableCachingNullValues()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(serializer));
+
+        return RedisCacheManager
+                .builder(connectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/upply/job/JobService.java
+++ b/src/main/java/com/upply/job/JobService.java
@@ -23,6 +23,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -64,6 +67,7 @@ public class JobService {
     private int TASK_EXPIRE_TIME;
 
     @Transactional
+    @CachePut(value = "JOB_CACHE", key = "#result.id")
     public JobResponse createJob(@Valid JobRequest request, Authentication connectedUser) {
 
         Set<Skill> skills = new HashSet<>(
@@ -122,6 +126,7 @@ public class JobService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "JOB_CACHE", key = "#id")
     public JobResponse getJob(Long id) {
 
         Job job = jobRepository.findById(id)
@@ -237,6 +242,7 @@ public class JobService {
     }
 
     @Transactional
+    @CacheEvict(value = "JOB_CACHE", key = "#id")
     public JobResponse closeJob(Long id, Authentication connectedUser) {
 
         Job job = jobRepository.findById(id)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,12 +62,15 @@ spring:
           jdbc:
             initialize-schema: always
 
-  #  data:
-#    redis:
-#      host: ${REDIS_HOST}
-#      port: ${REDIS_PORT}
-#      username: ${REDIS_USERNAME}
-#      password: ${REDIS_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      username: ${REDIS_USERNAME}
+      password: ${REDIS_PASSWORD}
+
+  cache:
+    type: redis
 
   servlet:
     multipart:

--- a/src/test/java/com/upply/config/RedisConfigTest.java
+++ b/src/test/java/com/upply/config/RedisConfigTest.java
@@ -1,0 +1,37 @@
+package com.upply.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Redis Caching Configuration Tests")
+class RedisConfigTest {
+
+    @Mock
+    private RedisConnectionFactory connectionFactory;
+
+    @Test
+    @DisplayName("Should create cache manager with proper configuration")
+    void shouldCreateCacheManagerWithProperConfiguration() {
+        RedisConfig redisConfig = new RedisConfig();
+        RedisCacheManager cacheManager = redisConfig.cacheManager(connectionFactory);
+
+        assertNotNull(cacheManager);
+    }
+
+    @Test
+    @DisplayName("Should use connection factory when building cache manager")
+    void shouldUseConnectionFactoryWhenBuildingCacheManager() {
+        RedisConfig redisConfig = new RedisConfig();
+        RedisCacheManager cacheManager = redisConfig.cacheManager(connectionFactory);
+
+        assertNotNull(cacheManager);
+    }
+}

--- a/src/test/java/com/upply/config/UpplyApplicationTests.java
+++ b/src/test/java/com/upply/config/UpplyApplicationTests.java
@@ -13,6 +13,7 @@ import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.vectorstore.VectorStore;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 
 @TestConfiguration
@@ -125,5 +126,10 @@ public class UpplyApplicationTests {
     @Bean
     public ChatMemory chatMemory() {
         return Mockito.mock(ChatMemory.class);
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return Mockito.mock(RedisConnectionFactory.class);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed caching to improve performance and reduce response times.
  * Job endpoints now use caching for faster retrieval, creation, and status updates.
* **Configuration**
  * Application now supports Redis connection via environment-configurable settings.
* **Tests**
  * Added unit tests to validate cache manager creation and Redis wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->