### PR TITLE
fix(job): add organization guard on createJob

### DIFF
--- a/src/main/java/com/upply/job/JobService.java
+++ b/src/main/java/com/upply/job/JobService.java
@@ -70,6 +70,13 @@ public class JobService {
     @CachePut(value = "JOB_CACHE", key = "#result.id")
     public JobResponse createJob(@Valid JobRequest request, Authentication connectedUser) {
 
+        User user = (User) connectedUser.getPrincipal();
+
+        if (user.getOrganization() == null) {
+            throw new OperationNotPermittedException(
+                    "You must be connected to an organization before creating a job");
+        }
+
         Set<Skill> skills = new HashSet<>(
                 skillRepository.findAllById(request.getSkillIds()));
 
@@ -79,8 +86,9 @@ public class JobService {
 
         Job job = jobMapper.toJob(request, skills);
 
-        User user = (User) connectedUser.getPrincipal();
         job.setPostedBy(user);
+        job.setOrganization(user.getOrganization());
+        job.setOrganizationName(user.getOrganization().getName());
 
         Job savedJob = jobRepository.save(job);
 

--- a/src/test/java/com/upply/job/JobServiceTest.java
+++ b/src/test/java/com/upply/job/JobServiceTest.java
@@ -21,6 +21,7 @@ import com.upply.job.dto.ExportTaskMapper;
 import com.upply.job.dto.MatchedJobListResponse;
 import com.upply.job.dto.JobListResponse;
 import com.upply.notification.dto.NotificationEvent;
+import com.upply.organization.Organization;
 import com.upply.profile.skill.Skill;
 import com.upply.profile.skill.SkillRepository;
 import com.upply.user.User;
@@ -92,6 +93,9 @@ class JobServiceTest {
     private User testUser;
 
     @Mock
+    private Organization testOrganization;
+
+    @Mock
     private Job testJob;
 
     @Mock
@@ -104,6 +108,8 @@ class JobServiceTest {
         TransactionSynchronizationManager.initSynchronization();
 
         when(testUser.getId()).thenReturn(1L);
+        when(testUser.getOrganization()).thenReturn(testOrganization);
+        when(testOrganization.getName()).thenReturn("Test Organization");
         when(testSkill.getId()).thenReturn(1L);
         when(testJob.getId()).thenReturn(1L);
         when(testJob.getTitle()).thenReturn("Software Engineer");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job creation now requires users to be associated with an organization; users without this connection will receive an error.
  * Jobs now properly record the organization that created them, improving data integrity and tracking accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->