### PR TITLE
fix: org auto-assigned on POST /connect without email verification

### DIFF
--- a/src/main/java/com/upply/organization/OrganizationRepository.java
+++ b/src/main/java/com/upply/organization/OrganizationRepository.java
@@ -18,4 +18,7 @@ public interface OrganizationRepository extends JpaRepository<Organization, Long
 
     @Query("SELECT j FROM Job j WHERE j.organization.id = :orgId AND j.status = :status")
     Page<Job> findJobsByOrganizationIdAndStatus(@Param("orgId") Long orgId, @Param("status") JobStatus status, Pageable pageable);
+
+    @Query("SELECT COUNT(r) > 0 FROM Organization o JOIN o.recruiters r WHERE o.id = :orgId AND r.id = :userId")
+    boolean existsRecruiterInOrganization(@Param("orgId") Long orgId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/upply/organization/OrganizationService.java
+++ b/src/main/java/com/upply/organization/OrganizationService.java
@@ -128,8 +128,7 @@ public class OrganizationService {
 
         if (existingOrg.isPresent()) {
             Organization org = existingOrg.get();
-            boolean isAlreadyRecruiter = org.getRecruiters().stream()
-                    .anyMatch(r -> r.getId().equals(user.getId()));
+            boolean isAlreadyRecruiter = organizationRepository.existsRecruiterInOrganization(org.getId(), user.getId());
 
             if (isAlreadyRecruiter) {
                 throw new BusinessLogicException("You are already connected to this organization.");

--- a/src/test/java/com/upply/organization/OrganizationServiceTest.java
+++ b/src/test/java/com/upply/organization/OrganizationServiceTest.java
@@ -267,13 +267,12 @@ class OrganizationServiceTest {
     @Test
     @DisplayName("initiateConnection should throw when user already connected to existing org")
     void shouldThrowWhenUserAlreadyConnectedToOrg() {
-        testOrganization.getRecruiters().add(testUser);
-
         ConnectToOrganizationRequest request = ConnectToOrganizationRequest.builder()
                 .businessEmail("user@techcorp.com")
                 .build();
 
         when(organizationRepository.findByDomain("techcorp.com")).thenReturn(Optional.of(testOrganization));
+        when(organizationRepository.existsRecruiterInOrganization(1L, 1L)).thenReturn(true);
 
         BusinessLogicException exception = assertThrows(
                 BusinessLogicException.class,
@@ -330,6 +329,22 @@ class OrganizationServiceTest {
                 eq(EmailTemplate.BUSINESS_EMAIL_VERIFICATION),
                 anyMap()
         );
+    }
+
+    @Test
+    @DisplayName("initiateConnection should not update user organization in database")
+    void shouldNotUpdateUserOrganizationOnInitiateConnection() throws JsonProcessingException {
+        ConnectToOrganizationRequest request = ConnectToOrganizationRequest.builder()
+                .businessEmail("user@techcorp.com")
+                .build();
+
+        when(organizationRepository.findByDomain("techcorp.com")).thenReturn(Optional.of(testOrganization));
+        when(tokenRepository.save(any(BusinessEmailVerificationToken.class))).thenReturn(null);
+
+        organizationService.initiateConnection(request, testUser);
+
+        verify(userRepository, never()).save(any(User.class));
+        assertNull(testUser.getOrganization());
     }
 
     // ==================== verifyAndConnect tests ====================


### PR DESCRIPTION
## Case
`initiateConnection` is annotated `@Transactional`, which means Hibernate keeps an open session for the entire method and tracks every entity it loads. When the code calls `org.getRecruiters()` to check whether the current user is already a member, Hibernate executes:
 
```sql
SELECT * FROM users WHERE organization_id = ?
```
 
and hydrates every result row into a managed `User` object. Because the bidirectional relationship is defined on both sides (`@OneToMany` on `Organization`, `@ManyToOne` on `User`), Hibernate automatically sets `user.organization = org` on each hydrated object to keep the in-memory object graph consistent with what it read from the database.
 
If the authenticated user's row happens to be in that result set — which it will be after any prior successful verification — the same managed principal that Spring Security injected into the request now has its `organization` field mutated in memory without any explicit assignment in application code.
 
At transaction commit, Hibernate's dirty-checking mechanism compares every managed entity against the snapshot it captured when the entity first entered the session. It detects that `user.organization` changed from `null` to `org` and silently emits:
 
```sql
UPDATE users SET organization_id = ? WHERE id = ?
```
 
with no call to `userRepository.save()` anywhere in the method.
