### PR TITLE
feat(user): add endpoint to get authenticated user's organization

### DIFF
--- a/src/main/java/com/upply/user/UserController.java
+++ b/src/main/java/com/upply/user/UserController.java
@@ -10,6 +10,7 @@ import com.upply.profile.skill.dto.SkillRequest;
 import com.upply.profile.skill.dto.SkillResponse;
 import com.upply.profile.socialLink.dto.SocialLinkRequest;
 import com.upply.profile.socialLink.dto.SocialLinkResponse;
+import com.upply.organization.dto.OrganizationResponse;
 import com.upply.user.dto.UserRequest;
 import com.upply.user.dto.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,6 +41,15 @@ public class UserController {
     )
     public ResponseEntity<UserResponse> getUser() {
         return ResponseEntity.ok(userService.getUser());
+    }
+
+    @GetMapping("/organization")
+    @Operation(
+            summary = "Get authenticated user's organization",
+            description = "Retrieves the organization that the authenticated user is connected to."
+    )
+    public ResponseEntity<OrganizationResponse> getUserOrganization() {
+        return ResponseEntity.ok(userService.getUserOrganization());
     }
 
     @PutMapping

--- a/src/main/java/com/upply/user/UserService.java
+++ b/src/main/java/com/upply/user/UserService.java
@@ -28,6 +28,8 @@ import com.upply.profile.socialLink.*;
 import com.upply.profile.socialLink.dto.SocialLinkMapper;
 import com.upply.profile.socialLink.dto.SocialLinkRequest;
 import com.upply.profile.socialLink.dto.SocialLinkResponse;
+import com.upply.organization.dto.OrganizationMapper;
+import com.upply.organization.dto.OrganizationResponse;
 import com.upply.user.dto.SkillEvent;
 import com.upply.user.dto.UserMapper;
 import com.upply.user.dto.UserRequest;
@@ -67,11 +69,23 @@ public class UserService {
     private final ResumeRepository resumeRepository;
     private final ResumeMapper resumeMapper;
     private final KafkaTemplate<String, SkillEvent> skillEventKafkaTemplate;
+    private final OrganizationMapper organizationMapper;
 
     public UserResponse getUser() {
         return userRepository.getCurrentUser()
                 .map(userMapper::toUserResponse)
                 .orElseThrow(() -> new ResourceNotFoundException("User Not Found"));
+    }
+
+    public OrganizationResponse getUserOrganization() {
+        User user = userRepository.getCurrentUser()
+                .orElseThrow(() -> new ResourceNotFoundException("User Not Found"));
+
+        if (user.getOrganization() == null) {
+            throw new ResourceNotFoundException("User is not connected to any organization");
+        }
+
+        return organizationMapper.toResponse(user.getOrganization());
     }
 
     public void updateUser(UserRequest userRequest) {

--- a/src/test/java/com/upply/user/UserServiceTest.java
+++ b/src/test/java/com/upply/user/UserServiceTest.java
@@ -12,6 +12,9 @@ import com.upply.profile.skill.*;
 import com.upply.profile.skill.dto.SkillMapper;
 import com.upply.profile.skill.dto.SkillRequest;
 import com.upply.profile.skill.dto.SkillResponse;
+import com.upply.organization.Organization;
+import com.upply.organization.dto.OrganizationMapper;
+import com.upply.organization.dto.OrganizationResponse;
 import com.upply.profile.socialLink.*;
 import com.upply.profile.socialLink.dto.SocialLinkMapper;
 import com.upply.profile.socialLink.dto.SocialLinkRequest;
@@ -74,6 +77,9 @@ class UserServiceTest {
 
     @Mock
     private KafkaTemplate<String, SkillEvent> skillEventKafkaTemplate;
+
+    @Mock
+    private OrganizationMapper organizationMapper;
 
     @InjectMocks
     private UserService userService;
@@ -1047,6 +1053,69 @@ class UserServiceTest {
         userService.deleteUserLinks(999L);
 
         verify(socialLinkRepository).deleteSocialLinkById(999L);
+    }
+
+    // getUserOrganization tests
+
+    @Test
+    @DisplayName("getUserOrganization should return organization when user is connected")
+    void shouldGetUserOrganizationSuccessfully() {
+        Organization testOrganization = Organization.builder()
+                .id(1L)
+                .name("Test Organization")
+                .domain("test.com")
+                .build();
+
+        OrganizationResponse testOrganizationResponse = OrganizationResponse.builder()
+                .id(1L)
+                .name("Test Organization")
+                .domain("test.com")
+                .build();
+
+        testUser.setOrganization(testOrganization);
+
+        when(userRepository.getCurrentUser()).thenReturn(Optional.of(testUser));
+        when(organizationMapper.toResponse(testOrganization)).thenReturn(testOrganizationResponse);
+
+        OrganizationResponse result = userService.getUserOrganization();
+
+        assertNotNull(result);
+        assertEquals(testOrganizationResponse, result);
+        assertEquals("Test Organization", result.getName());
+        verify(userRepository).getCurrentUser();
+        verify(organizationMapper).toResponse(testOrganization);
+    }
+
+    @Test
+    @DisplayName("getUserOrganization should throw ResourceNotFoundException when user has no organization")
+    void shouldThrowExceptionWhenUserNotConnectedToOrganization() {
+        testUser.setOrganization(null);
+
+        when(userRepository.getCurrentUser()).thenReturn(Optional.of(testUser));
+
+        ResourceNotFoundException exception = assertThrows(
+                ResourceNotFoundException.class,
+                () -> userService.getUserOrganization()
+        );
+
+        assertEquals("User is not connected to any organization", exception.getMessage());
+        verify(userRepository).getCurrentUser();
+        verify(organizationMapper, never()).toResponse(any());
+    }
+
+    @Test
+    @DisplayName("getUserOrganization should throw ResourceNotFoundException when user does not exist")
+    void shouldThrowExceptionWhenUserNotFoundInGetUserOrganization() {
+        when(userRepository.getCurrentUser()).thenReturn(Optional.empty());
+
+        ResourceNotFoundException exception = assertThrows(
+                ResourceNotFoundException.class,
+                () -> userService.getUserOrganization()
+        );
+
+        assertEquals("User Not Found", exception.getMessage());
+        verify(userRepository).getCurrentUser();
+        verify(organizationMapper, never()).toResponse(any());
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retrieve their organization information through a new authenticated endpoint. This enhancement provides direct access to organizational details linked to the user account, enabling streamlined views of organization-related data and supporting improved workflows. The feature is now available for all authenticated users accessing their accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/upply-org/upply-backend/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->