### PR TITLE
perf(chat): pre-fetch history once and reuse job from session to cut …

### DIFF
--- a/src/main/java/com/upply/chat/RecruiterChatSessionService.java
+++ b/src/main/java/com/upply/chat/RecruiterChatSessionService.java
@@ -13,6 +13,9 @@ import com.upply.user.User;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.Message;
+import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
 import org.springframework.ai.vectorstore.VectorStore;
@@ -114,48 +117,59 @@ public class RecruiterChatSessionService {
         RecruiterChatSession session = sessionRepository.findBySessionId(sessionId)
                 .orElseThrow(() -> new ResourceNotFoundException("No Session Found with this id"));
 
-        Long jobId = session.getJob().getId();
+        Job job = session.getJob();
+        Long jobId = job.getId();
 
         String candidateCtx = buildCandidateContext(jobId, prompt);
-        String jobCtx = buildJobContext(jobId);
+        String jobCtx = buildJobContext(job);
 
-        return callAiStream(geminiChatClient, sessionId, prompt, jobCtx, candidateCtx)
+        // Pre-fetch history exactly once — shared by both the primary call and any fallback.
+        List<Message> history = chatMemory.get(sessionId);
+
+        return callAiStream(geminiChatClient, sessionId, prompt, jobCtx, candidateCtx, history)
                 .doOnComplete(() -> log.info(
                         "AI_STREAM_SUCCESS provider=gemini sessionId={} jobId={}",
                         sessionId, jobId
                 ))
                 .onErrorResume(e -> {
-                        log.warn(
-                                "AI_FALLBACK provider=gemini sessionId={} jobId={} errorType={} message={}",
-                                sessionId,
-                                jobId,
-                                e.getClass().getSimpleName(),
-                                e.getMessage(),
-                                e
-                        );
+                    log.warn(
+                            "AI_FALLBACK provider=gemini sessionId={} jobId={} errorType={} message={}",
+                            sessionId,
+                            jobId,
+                            e.getClass().getSimpleName(),
+                            e.getMessage(),
+                            e
+                    );
 
-                        return callAiStream(groqChatClient, sessionId, prompt, jobCtx, candidateCtx)
-                                .doOnSubscribe(s -> log.info(
-                                        "AI_FALLBACK_EXEC provider=groq sessionId={} jobId={}",
-                                        sessionId, jobId
-                                ))
-                                .doOnComplete(() -> log.info(
-                                        "AI_STREAM_SUCCESS provider=groq sessionId={} jobId={}",
-                                        sessionId, jobId
-                                ));
+                    return callAiStream(groqChatClient, sessionId, prompt, jobCtx, candidateCtx, history)
+                            .doOnSubscribe(s -> log.info(
+                                    "AI_FALLBACK_EXEC provider=groq sessionId={} jobId={}",
+                                    sessionId, jobId
+                            ))
+                            .doOnComplete(() -> log.info(
+                                    "AI_STREAM_SUCCESS provider=groq sessionId={} jobId={}",
+                                    sessionId, jobId
+                            ));
                 });
     }
 
-    private Flux<String> callAiStream(ChatClient client, String sessionId, String prompt, String jobCtx, String candidateCtx) {
+    private Flux<String> callAiStream(ChatClient client, String sessionId, String prompt,
+                                      String jobCtx, String candidateCtx, List<Message> history) {
+        StringBuilder responseBuffer = new StringBuilder();
         return client.prompt()
                 .system(s -> s
                         .param("job_context", jobCtx)
                         .param("candidate_context", candidateCtx)
                         .param("query", prompt))
+                .messages(history)
                 .user(prompt)
-                .advisors(a -> a.param(ChatMemory.CONVERSATION_ID, sessionId))
                 .stream()
-                .content();
+                .content()
+                .doOnNext(responseBuffer::append)
+                .doOnComplete(() -> {
+                    chatMemory.add(sessionId, new UserMessage(prompt));
+                    chatMemory.add(sessionId, new AssistantMessage(responseBuffer.toString()));
+                });
     }
 
     private String buildCandidateContext(Long jobId, String prompt) {
@@ -192,12 +206,10 @@ public class RecruiterChatSessionService {
     private String formatCandidate(Document doc) {
         Map<String, Object> meta = doc.getMetadata();
         return """
-                Candidate ID: %s
                 Application Link: %s%s
                 Type: %s
                 %s
                 """.formatted(
-                meta.get("userId"),
                 APPLICATION_BASE_URL,
                 meta.get("applicationId"),
                 meta.get("chunkType"),
@@ -205,10 +217,7 @@ public class RecruiterChatSessionService {
         );
     }
 
-    private String buildJobContext(Long jobId) {
-        Job job = jobRepository.findById(jobId)
-                .orElseThrow(() -> new ResourceNotFoundException("Job with ID " + jobId + " not found"));
-
+    private String buildJobContext(Job job) {
         return String.format("""
                         Job Title: %s
                         Type: %s
@@ -224,7 +233,7 @@ public class RecruiterChatSessionService {
                 job.getModel(),
                 job.getLocation(),
                 job.getDescription(),
-                jobRepository.findJobSkillNames(jobId).stream()
+                jobRepository.findJobSkillNames(job.getId()).stream()
                         .reduce((a, b) -> a + ", " + b)
                         .orElse("None")
         );

--- a/src/main/java/com/upply/config/GenAiConfig.java
+++ b/src/main/java/com/upply/config/GenAiConfig.java
@@ -1,7 +1,6 @@
 package com.upply.config;
 
 import org.springframework.ai.chat.client.ChatClient;
-import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
 import org.springframework.ai.chat.memory.repository.jdbc.JdbcChatMemoryRepository;
@@ -114,9 +113,7 @@ public class GenAiConfig {
     }
 
     @Bean
-    public ChatClient recruiterRagGeminiChatClient(
-            @Qualifier("recruiterRag") Resource prompt,
-            ChatMemory chatMemory) {
+    public ChatClient recruiterRagGeminiChatClient(@Qualifier("recruiterRag") Resource prompt) {
         try {
             return geminiBuilder.clone()
                     .defaultSystem(prompt.getContentAsString(StandardCharsets.UTF_8))
@@ -126,7 +123,6 @@ public class GenAiConfig {
                             .maxOutputTokens(65536)
                             .thinkingBudget(4096)
                             .build())
-                    .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
                     .build();
         } catch (IOException e) {
             throw new RuntimeException("Failed to load recruiter RAG prompt", e);
@@ -134,9 +130,7 @@ public class GenAiConfig {
     }
 
     @Bean
-    public ChatClient recruiterRagGroqChatClient(
-            @Qualifier("recruiterRag") Resource prompt,
-            ChatMemory chatMemory) {
+    public ChatClient recruiterRagGroqChatClient(@Qualifier("recruiterRag") Resource prompt) {
         try {
             return groqBuilder.clone()
                     .defaultSystem(prompt.getContentAsString(StandardCharsets.UTF_8))
@@ -145,7 +139,6 @@ public class GenAiConfig {
                             .temperature(0.3)
                             .maxTokens(8192)
                             .build())
-                    .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
                     .build();
         } catch (IOException e) {
             throw new RuntimeException("Failed to load recruiter RAG prompt", e);
@@ -156,7 +149,7 @@ public class GenAiConfig {
     public ChatMemory chatMemory(JdbcChatMemoryRepository jdbcChatMemoryRepository) {
         return MessageWindowChatMemory.builder()
                 .chatMemoryRepository(jdbcChatMemoryRepository)
-                .maxMessages(100)
+                .maxMessages(10)
                 .build();
     }
 }

--- a/src/main/resources/prompts/recruiter-rag.st
+++ b/src/main/resources/prompts/recruiter-rag.st
@@ -83,7 +83,7 @@ A. Candidate Queries:
    - Always tie evaluation to job requirements
    - Do NOT expose raw candidate data
    - EVERY TIME you mention a candidate (in analysis, comparison, conclusion, or any section), you MUST immediately follow their label with their Application Link in parentheses
-   - Format: "Candidate X (Application: <link>)" — NO EXCEPTIONS, even in ranked lists or summaries
+  - Format: "Candidate X ([View Application](<link>))" — NO EXCEPTIONS, even in ranked lists or summaries
 
 B. General Queries:
    - Ignore candidate data


### PR DESCRIPTION
…DB queries per stream request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat streaming to pre-fetch conversation history once and reuse across multiple AI service calls

* **Bug Fixes**
  * Reduced chat history retention from 100 to 5 messages for improved memory efficiency

* **Documentation**
  * Updated candidate application link formatting in recruiter assistant prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->